### PR TITLE
Enable Vite plugin in preview mode

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -55,39 +55,43 @@ export interface VitePluginOptions extends MiddlewareConfiguration {
     enabled?: "serve" | "preview" | boolean;
 }
 
-/**
- * Configure apimock-express.
- */
-export function config(
-    mocks: MockEntry | MockEntry[],
-    config?: Partial<MiddlewareConfiguration>,
-): void;
+declare namespace apimock {
+    /**
+     * Configure apimock-express.
+     */
+    function config(
+        mocks: MockEntry | MockEntry[],
+        config?: Partial<MiddlewareConfiguration>,
+    ): void;
 
-/**
- * Express/Connect middleware.
- *
- * Usage:
- *
- * ```ts
- * app.use("*", mockRequest);
- * ```
- */
-export function mockRequest(
-    request: Request,
-    response: Response,
-    next: NextFunction,
-): void;
+    /**
+     * Express/Connect middleware.
+     *
+     * Usage:
+     *
+     * ```ts
+     * app.use("*", mockRequest);
+     * ```
+     */
+    function mockRequest(
+        request: Request,
+        response: Response,
+        next: NextFunction,
+    ): void;
 
-/**
- * Vite plugin for apimock-express.
- *
- * @param mocks - Mock configuration
- * @param options - Plugin options
- * @returns A Vite plugin instance.
- */
-export function vitePlugin(
-    mocks: MockEntry[],
-    options?: VitePluginOptions,
-): {
-    name: "apimock-plugin";
-};
+    /**
+     * Vite plugin for apimock-express.
+     *
+     * @param mocks - Mock configuration
+     * @param options - Plugin options
+     * @returns A Vite plugin instance.
+     */
+    export function vitePlugin(
+        mocks: MockEntry[],
+        options?: VitePluginOptions,
+    ): {
+        name: "apimock-plugin";
+    };
+}
+
+export = apimock;

--- a/main.d.ts
+++ b/main.d.ts
@@ -37,7 +37,22 @@ export interface MockEntry {
  * Configuration options for the middleware.
  */
 export interface MiddlewareConfiguration {
-    verbose: boolean;
+    /**
+     * If enabled a summary of the configured mock will be displayed. Default is
+     *`true`.
+     */
+    verbose?: boolean;
+}
+
+/**
+ * Options for Vite plugin.
+ */
+export interface VitePluginOptions extends MiddlewareConfiguration {
+    /**
+     * Enable/disable plugin. Can optionally be set to which command to enable
+     * the plugin for. Default is `true` (enabled for all commands).
+     */
+    enabled?: "serve" | "preview" | boolean;
 }
 
 /**
@@ -67,8 +82,12 @@ export function mockRequest(
  * Vite plugin for apimock-express.
  *
  * @param mocks - Mock configuration
+ * @param options - Plugin options
  * @returns A Vite plugin instance.
  */
-export function vitePlugin(mocks: MockEntry[]): {
+export function vitePlugin(
+    mocks: MockEntry[],
+    options?: VitePluginOptions,
+): {
     name: "apimock-plugin";
 };

--- a/main.js
+++ b/main.js
@@ -157,6 +157,10 @@ const apimock = {
                 apimock.config(mocks);
                 server.middlewares.use("/", apimock.mockRequest);
             },
+            configurePreviewServer(server) {
+                apimock.config(mocks);
+                server.middlewares.use("/", apimock.mockRequest);
+            },
         };
     },
 };

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ const { version } = require("./package.json");
 /**
  * @typedef {import("./main").MockEntry} MockEntry
  * @typedef {import("./main").MiddlewareConfiguration} MiddlewareConfiguration
+ * @typedef {import("./main").VitePluginOptions} VitePluginOptions
  */
 
 /** @type {MockEntry[]} */
@@ -148,18 +149,24 @@ const apimock = {
      * Vite plugin for apimock-express.
      *
      * @param {MockEntry[]} mocks - Mock configuration
+     * @param {VitePluginOptions} [options] - Options
      * @returns {Plugin}
      */
-    vitePlugin(mocks) {
+    vitePlugin(mocks, options = {}) {
+        const { enabled = true } = options;
         return {
             name: "apimock-plugin",
             configureServer(server) {
-                apimock.config(mocks);
-                server.middlewares.use("/", apimock.mockRequest);
+                if (enabled === true || enabled === "serve") {
+                    apimock.config(mocks, options);
+                    server.middlewares.use("/", apimock.mockRequest);
+                }
             },
             configurePreviewServer(server) {
-                apimock.config(mocks);
-                server.middlewares.use("/", apimock.mockRequest);
+                if (enabled === true || enabled === "preview") {
+                    apimock.config(mocks, options);
+                    server.middlewares.use("/", apimock.mockRequest);
+                }
             },
         };
     },


### PR DESCRIPTION
Enable usage of apimock plugin in Vite preview mode, default is enabled but is also configurable with `vitePlugin([ ... ], { enabled: "serve" })`.