### PR TITLE
fix: print proper path in debug log

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -274,22 +274,15 @@ function getFilepath(
     const files = globSync(globPattern);
 
     const wildcard = globSync(wildcardPattern);
+    const resolvedPath = path.resolve(process.cwd(), globPattern);
     if (files.length === 0) {
         if (wildcard.length === 1) {
             return wildcard[0];
         }
-        throw Error(
-            `Cannot find file matching glob ${process.cwd()}/${globPattern.replace(
-                /^(?:\.\.\/)+/,
-                "",
-            )}`,
-        );
+        throw Error(`Cannot find file matching glob ${resolvedPath})`);
     } else if (files.length > 1) {
         console.warn(
-            `Found multiple files matching glob ${process.cwd()}/${globPattern.replace(
-                /^(?:\.\.\/)+/,
-                "",
-            )}, using ${files[0]}, found:`,
+            `Found multiple files matching glob ${resolvedPath}, using ${files[0]}, found:`,
             files,
         );
     }


### PR DESCRIPTION
Current log text do not print resolved path when using `../` in folder path.

Given config
```
apimock.config([
    { url: "/api/bar", dir: "../../../tests/mock/bar" },
]);
```

Current path:  `/home/olof/repos/apimock-express`

Expected debug text when trying to fetch /api/bar 
`Error: Cannot find file matching glob /home/tests/mock/bar.*{js,json})`

Actual debug text
`Error: Cannot find file matching glob /home/olof/repos/apimock-express/tests/mock/bar.*{js,json}`

