### PR TITLE
feat: support .cjs-files

### DIFF
--- a/src/node/extract-file-content.ts
+++ b/src/node/extract-file-content.ts
@@ -10,6 +10,7 @@ export function extractFileContent(filepath: string): string {
     switch (path.extname(filepath)) {
         case ".json":
             return fs.readFileSync(filepath, { encoding: "utf8" });
+        case ".cjs":
         case ".js": {
             /* eslint-disable-next-line import/no-dynamic-require, @typescript-eslint/no-require-imports --
              * filename depends on config and isn't known until runtime */

--- a/test/api/js/commonjs.cjs
+++ b/test/api/js/commonjs.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+    default: {
+        defaultResponse: {
+            body: {
+                foo: "cjs",
+            },
+        },
+    },
+};

--- a/test/commontest/js.spec.mjs
+++ b/test/commontest/js.spec.mjs
@@ -39,4 +39,17 @@ describe("js mocks", function () {
             "app/private/../v1",
         );
     });
+
+    test("commonjs file (.cjs)", async () => {
+        const res = await fetch(`http://${hostname}/api/js/commonjs`, {
+            method: "get",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
+        const body = await res.json();
+        expect(body).to.deep.equal({
+            foo: "cjs",
+        });
+    });
 });


### PR DESCRIPTION
... in order to make it more clear that the mock (for now) only support commonjs and not ESM files.

In the future it would make more sense to support ESM and even making ESM primary type, but that will have to be in another PR. Still waiting for sync require of ESM file without the experiment-flag ;) 