### PR TITLE
fix: transform to pathToFileURL before import of file

### DIFF
--- a/src/node/extract-file-content.ts
+++ b/src/node/extract-file-content.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path/posix";
+import url from "node:url";
+
 import { type Mock } from "../mockfile";
 
 function parseJson(filepath: string, fileContent: string): Mock {
@@ -30,7 +32,9 @@ export async function extractFileContent(filepath: string): Promise<Mock> {
         case ".js":
         case ".cjs":
         case ".mjs": {
-            let { default: mock } = (await import(filepath)) as {
+            let { default: mock } = (await import(
+                url.pathToFileURL(filepath).toString()
+            )) as {
                 default: Mock | { default: Mock };
             };
 


### PR DESCRIPTION
I guess this is related to Windows (Cannot reproduce in linux env)


This is when i'm using the new generateForBrowser func.
```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

