### PR TITLE
fix: do not append fix for malformed export if it returns a string

### DIFF
--- a/src/node/extract-file-content.ts
+++ b/src/node/extract-file-content.ts
@@ -37,7 +37,7 @@ export async function extractFileContent(filepath: string): Promise<Mock> {
             /* this should never really be required but a malformed "default"
              * export in commonjs might (such as testcases in this repo does)
              * would behave like this as it is not a proper default export */
-            if ("default" in mock) {
+            if (typeof mock !== "string" && "default" in mock) {
                 mock = mock.default;
             }
 


### PR DESCRIPTION
Internal mock files contains following code:

```
mock = {...}
module.exports = JSON.stringify(mock);
```

Seems very odd, but i think the safest approach is to apply this check until all mocks are updated (probably never)