### PR TITLE
test: run tests on windows node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
     build:
-        runs-on: ubuntu-latest
         strategy:
             matrix:
+                os: [windows-latest, ubuntu-latest]
                 node-version: [20.x, 22.x, 24.x]
+        runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v5
             - name: Use Node.js ${{ matrix.node-version }}
@@ -23,7 +24,7 @@ jobs:
             - name: Selftest
               run: npm run --if-present selftest
             - name: Integration test
-              if: matrix.node-version == '20.x'
+              if: matrix.os == 'ubuntu-latest'
               env:
                   WAIT_ON_TIMEOUT: 5000
               run: npm run vite


### PR DESCRIPTION
There is problems when running int tests on windows (due to limits in package `start-server-and-test`), so they are skipped for now

Regarding windows limit in package:
https://github.com/bahmutov/start-server-and-test/issues/398