### PR TITLE
fix: rewrite way of generating mocks for browser

### DIFF
--- a/etc/apimock-express-browser.api.md
+++ b/etc/apimock-express-browser.api.md
@@ -7,6 +7,11 @@
 // @public
 export function appendBasePath(mocks: Mock[], basePath: string): Mock[];
 
+// Warning: (ae-forgotten-export) The symbol "GenerateForBrowserResponse" needs to be exported by the entry point browser.d.ts
+//
+// @beta
+export function generateMock(list: GenerateForBrowserResponse[]): Promise<Mock[]>;
+
 // @public
 export function matchResponse(options: {
     mockdata: Mock[];

--- a/etc/apimock-express-main.api.md
+++ b/etc/apimock-express-main.api.md
@@ -17,8 +17,10 @@ const apimock: {
 };
 export default apimock;
 
+// Warning: (ae-forgotten-export) The symbol "GenerateForBrowserResponse" needs to be exported by the entry point main.d.ts
+//
 // @beta
-export function generateForBrowser(apiDirectory: string, userOptions?: GenerateForBrowserOptions): Promise<Mock[]>;
+export function generateForBrowser(apiDirectory: string, userOptions?: GenerateForBrowserOptions): Promise<GenerateForBrowserResponse[]>;
 
 // @beta (undocumented)
 export interface GenerateForBrowserOptions {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,7 +11,7 @@ export {
     type MockRequest,
 } from "./mockfile";
 export { selectResponse, matchResponse, appendBasePath } from "./common";
-
+export { generateMock } from "./browser/generate-mock";
 /**
  * Respond the given mockdata based by url, cookie, request parameters and headers-
  *

--- a/src/browser/generate-mock.ts
+++ b/src/browser/generate-mock.ts
@@ -1,0 +1,29 @@
+import { type Mock } from "../helpers";
+import { type GenerateForBrowserResponse } from "../node/generateForBrowser";
+
+/**
+ * Generate a list of Mock objects from GenerateForBrowserResponse function
+ * @beta
+ */
+export async function generateMock(
+    list: GenerateForBrowserResponse[],
+): Promise<Mock[]> {
+    const mockList: Mock[] = [];
+
+    for (const item of list) {
+        let { default: mock } = (await import(item.filePath.toString())) as {
+            default: Mock | { default: Mock };
+        };
+
+        /* this should never really be required but a malformed "default"
+         * export in commonjs might (such as testcases in this repo does)
+         * would behave like this as it is not a proper default export */
+        if ("default" in mock) {
+            mock = mock.default;
+        }
+
+        mock.meta = { url: item.url, method: item.method };
+        mockList.push(mock);
+    }
+    return mockList;
+}

--- a/test/browser/generateForBrowsers.spec.mjs
+++ b/test/browser/generateForBrowsers.spec.mjs
@@ -1,12 +1,20 @@
 import { describe, expect, test } from "vitest";
 import { generateForBrowser } from "../../src/main";
-import { appendBasePath, matchResponse } from "../../src/browser";
+import { appendBasePath, matchResponse, generateMock } from "../../src/browser";
 
-const mockData = await generateForBrowser("test/generateForBrowser", {
-    rootPath: process.cwd(),
-});
+async function testGenerateMock(apiDirectory, userOptions = {}) {
+    /** To be run in a Node Context */
+    const preparedMockData = await generateForBrowser(
+        apiDirectory,
+        userOptions,
+    );
+
+    /** To be run in a Browser Context */
+    return await generateMock(preparedMockData);
+}
+
 const config = {
-    mockdata: mockData,
+    mockdata: await testGenerateMock("test/generateForBrowser"),
     requestUrl: "/deeply/private/fancyApi",
     method: "GET",
     bodyParameters: {},
@@ -94,7 +102,7 @@ describe("generateForBrowser", function () {
             const customConfig = {
                 ...config,
             };
-            customConfig.mockdata = await generateForBrowser(
+            customConfig.mockdata = await testGenerateMock(
                 "test/generateForBrowser",
                 {
                     rootPath: process.cwd(),
@@ -116,7 +124,7 @@ describe("generateForBrowser", function () {
             const customConfig = {
                 ...config,
             };
-            customConfig.mockdata = await generateForBrowser(
+            customConfig.mockdata = await testGenerateMock(
                 "test/generateForBrowser",
                 {
                     rootPath: process.cwd(),


### PR DESCRIPTION
Earlier function worked great for JSON mocks (or simple ones in JS) but did not work when using Dates, Map or functions.

This rewrite __should__ fix that issue.

Need some help with the naming of the functions :innocent: 
```
generateForBrowser - to be called in node 
generateMock  - to be called in browser (using results from prev function)
```