### PR TITLE
test: eslint config for vitest

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import defaultConfig, { defineConfig } from "@forsakringskassan/eslint-config";
 import cliConfig from "@forsakringskassan/eslint-config-cli";
 import typescriptConfig from "@forsakringskassan/eslint-config-typescript";
 import typeinfoConfig from "@forsakringskassan/eslint-config-typescript-typeinfo";
+import vitestConfig from "@forsakringskassan/eslint-config-vitest";
 
 export default [
     defineConfig({
@@ -22,6 +23,16 @@ export default [
     typescriptConfig(),
     typeinfoConfig(import.meta.dirname, {
         ignores: ["*.d.ts", "**/vite.config.cts", "**/vite.config.mts"],
+    }),
+
+    vitestConfig(),
+
+    defineConfig({
+        name: "local/spec-files-vitest-compat",
+        files: ["**/*.spec.{ts,mjs}"],
+        rules: {
+            "vitest/valid-expect": "off",
+        },
     }),
 
     defineConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@forsakringskassan/eslint-config-cli": "14.1.0",
         "@forsakringskassan/eslint-config-typescript": "14.1.0",
         "@forsakringskassan/eslint-config-typescript-typeinfo": "14.1.0",
+        "@forsakringskassan/eslint-config-vitest": "14.1.1",
         "@forsakringskassan/prettier-config": "3.3.6",
         "@html-validate/release-scripts": "7.1.19",
         "@microsoft/api-extractor": "7.58.1",
@@ -912,6 +913,22 @@
       "peerDependencies": {
         "eslint": "^9.0.0",
         "typescript": "^3.0.1 || ^4.0.2 || ^5.0.2 || ^6.0.2"
+      }
+    },
+    "node_modules/@forsakringskassan/eslint-config-vitest": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@forsakringskassan/eslint-config-vitest/-/eslint-config-vitest-14.1.1.tgz",
+      "integrity": "sha512-Y3PlC1xamIw9X5yF0HJtWGoG54FgDtqhldWUuwZQl9pL55STBbzyePCGKRA9buuCyGzrWAQfEzYjWnnLj3OvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/eslint-plugin": "1.6.14"
+      },
+      "engines": {
+        "node": ">= 22.13"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0"
       }
     },
     "node_modules/@forsakringskassan/prettier-config": {
@@ -2260,6 +2277,37 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.6.14",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.14.tgz",
+      "integrity": "sha512-PXZ5ysw4eHU9h8nDtBvVcGC7Z2C/T9CFdheqSw1NNXFYqViojub0V9bgdYI67iBTOcra2mwD0EYldlY9bGPf2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.58.0",
+        "@typescript-eslint/utils": "^8.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "*",
+        "eslint": ">=8.57.0",
+        "typescript": ">=5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@forsakringskassan/eslint-config-cli": "14.1.0",
     "@forsakringskassan/eslint-config-typescript": "14.1.0",
     "@forsakringskassan/eslint-config-typescript-typeinfo": "14.1.0",
+    "@forsakringskassan/eslint-config-vitest": "14.1.1",
     "@forsakringskassan/prettier-config": "3.3.6",
     "@html-validate/release-scripts": "7.1.19",
     "@microsoft/api-extractor": "7.58.1",

--- a/src/browser/get-cookies.spec.ts
+++ b/src/browser/get-cookies.spec.ts
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getCookies } from "./get-cookies";
 
 describe("getCookies", function () {
-    test("parse cookies into object", () => {
+    it("parse cookies into object", () => {
+        expect.assertions(1);
         vi.spyOn(document, "cookie", "get").mockImplementation(
             () =>
                 "tz=Europe%2FStockholm; preferredMode=light; _octo=GH__; cpuBucket=lg",
@@ -17,7 +18,8 @@ describe("getCookies", function () {
         });
     });
 
-    test("should generate empty object if no cookies defined", () => {
+    it("should generate empty object if no cookies defined", () => {
+        expect.assertions(1);
         vi.spyOn(document, "cookie", "get").mockImplementation(() => "");
         expect(getCookies()).toEqual({});
     });

--- a/src/browser/get-request-params-from-url.spec.ts
+++ b/src/browser/get-request-params-from-url.spec.ts
@@ -1,11 +1,14 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getRequestParamsFromUrl } from "./get-request-params-from-url";
 
 describe("getRequestParams", function () {
-    test("should generate empty object if no params defined", () => {
+    it("should generate empty object if no params defined", () => {
+        expect.assertions(1);
         expect(getRequestParamsFromUrl("/private/api")).toEqual({});
     });
-    test("should generate object with parameters", () => {
+
+    it("should generate object with parameters", () => {
+        expect.assertions(1);
         expect(getRequestParamsFromUrl("/private/api?bar=foo&foo=bar")).toEqual(
             {
                 bar: "foo",

--- a/src/common/append-base-path.spec.ts
+++ b/src/common/append-base-path.spec.ts
@@ -1,13 +1,16 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it } from "vitest";
 import { type Mock } from "../helpers";
 import { appendBasePath } from "./append-base-path";
 
 describe("appendBasePath", () => {
-    test("should handle an empty array of mocks without throwing an error", () => {
+    it("should handle an empty array of mocks without throwing an error", () => {
+        expect.assertions(1);
         const result = appendBasePath([], "N/A");
         expect(result).toEqual([]);
     });
-    test("should correctly prepend the basePath to all mock URLs", () => {
+
+    it("should correctly prepend the basePath to all mock URLs", () => {
+        expect.assertions(2);
         const basePath = "/api/v1";
         const mocks: Mock[] = [
             {
@@ -25,11 +28,12 @@ describe("appendBasePath", () => {
         ];
 
         const result = appendBasePath(mocks, basePath);
-        expect(result[0]?.meta?.url).toEqual("/api/v1/users");
-        expect(result[1]?.meta?.url).toEqual("/api/v1/products");
+        expect(result[0]?.meta?.url).toBe("/api/v1/users");
+        expect(result[1]?.meta?.url).toBe("/api/v1/products");
     });
 
-    test("should throw an error if a mock is missing meta information", () => {
+    it("should throw an error if a mock is missing meta information", () => {
+        expect.assertions(1);
         const basePath = "/api/v1";
         const mocks: Mock[] = [
             {

--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it } from "vitest";
 import { type MockCookieValue, createMockByCookie } from "./helpers";
 
 describe("createMockByCookie", () => {
-    test("should succesfully create mock with static responses", () => {
+    it("should succesfully create mock with static responses", () => {
+        expect.assertions(1);
         // Given
         const getSomethingMockCookie = {
             name: "api-get-something",
@@ -91,7 +92,8 @@ describe("createMockByCookie", () => {
         });
     });
 
-    test("should successfully create mock with a dynamic response", () => {
+    it("should successfully create mock with a dynamic response", () => {
+        expect.assertions(2);
         // Given
         const postDynamicMockCookie = {
             name: "api-post-dynamic",

--- a/test/browser/basic-mock-test.spec.mjs
+++ b/test/browser/basic-mock-test.spec.mjs
@@ -1,16 +1,17 @@
 // @vitest-environment happy-dom
 /* global document */
 
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { matchResponseBrowser } from "../../src/browser";
 import basicMockPost from "./basic-mock-post.mjs";
 import basicMock from "./basic-mock.mjs";
 
-describe("Browser", function () {
+describe("browser", function () {
     afterEach(() => {
         vi.restoreAllMocks();
     });
-    describe("Basic", function () {
+
+    describe("basic", function () {
         const config = {
             mockdata: [basicMock, basicMockPost],
             requestUrl: "/private/foo/basic",
@@ -19,7 +20,8 @@ describe("Browser", function () {
             headers: undefined,
         };
 
-        test("Should get default GET-response", async () => {
+        it("should get default GET-response", async () => {
+            expect.assertions(1);
             const response = matchResponseBrowser(config);
             expect(response).to.deep.equal({
                 body: { foo: "bar" },
@@ -28,7 +30,8 @@ describe("Browser", function () {
             });
         });
 
-        test("Should remove query params in url", async () => {
+        it("should remove query params in url", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
                 requestUrl: "/private/foo/basic?foo=bar",
@@ -41,7 +44,8 @@ describe("Browser", function () {
             });
         });
 
-        test("Should get specific GET-response", async () => {
+        it("should get specific GET-response", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
                 requestUrl: "/private/foo/basic?foo=bar&bar=foo",
@@ -54,7 +58,8 @@ describe("Browser", function () {
             });
         });
 
-        test("Should get specific GET-response based on cookies", async () => {
+        it("should get specific GET-response based on cookies", async () => {
+            expect.assertions(1);
             vi.spyOn(document, "cookie", "get").mockImplementation(
                 () => "foo=bar",
             );
@@ -69,7 +74,8 @@ describe("Browser", function () {
             });
         });
 
-        test("Should get default POST-response", async () => {
+        it("should get default POST-response", async () => {
+            expect.assertions(1);
             const customConfig = { ...config, method: "POST" };
             const response = matchResponseBrowser(customConfig);
             expect(response).to.deep.equal({

--- a/test/browser/generate-for-browsers.spec.mjs
+++ b/test/browser/generate-for-browsers.spec.mjs
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, it } from "vitest";
 import { appendBasePath, matchResponseBrowser } from "../../src/browser";
 import { generateForBrowser } from "../../src/main";
 
@@ -17,7 +17,8 @@ const config = {
 
 describe("generateForBrowser", function () {
     describe("generateForBrowser", function () {
-        test("Should return default response for .js", async () => {
+        it("should return default response for .js", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
             };
@@ -31,7 +32,8 @@ describe("generateForBrowser", function () {
             });
         });
 
-        test("Should return post", async () => {
+        it("should return post", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
             };
@@ -47,7 +49,8 @@ describe("generateForBrowser", function () {
             });
         });
 
-        test("Should return default response for .json", async () => {
+        it("should return default response for .json", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
             };
@@ -62,7 +65,8 @@ describe("generateForBrowser", function () {
             });
         });
 
-        test("Should return default response for .cjs", async () => {
+        it("should return default response for .cjs", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
             };
@@ -77,7 +81,8 @@ describe("generateForBrowser", function () {
             });
         });
 
-        test("Should return default response for .esm", async () => {
+        it("should return default response for .esm", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
             };
@@ -92,7 +97,8 @@ describe("generateForBrowser", function () {
             });
         });
 
-        test("Should be able to define base api path", async () => {
+        it("should be able to define base api path", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
             };
@@ -114,7 +120,8 @@ describe("generateForBrowser", function () {
             });
         });
 
-        test("Should be able to append a basePath afterwards with using appendBasePath", async () => {
+        it("should be able to append a basePath afterwards with using appendBasePath", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
             };

--- a/test/browser/match-request.spec.mjs
+++ b/test/browser/match-request.spec.mjs
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 /* global document */
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { matchRequest } from "../../src/browser";
 import advancedGetMock from "../api/js/body-fn.mjs";
 import advancedPostMock from "../api/js/body-fn_post.mjs";
@@ -15,9 +15,10 @@ async function getMockResponse(url, method = "GET", headers = {}, body) {
     );
 }
 
-describe("Browser", function () {
+describe("browser", function () {
     describe("matchMockByRequest", function () {
-        test("Should return 404 response if no match", async () => {
+        it("should return 404 response if no match", async () => {
+            expect.assertions(2);
             const response = await getMockResponse("/not-found", "GET", {
                 "Content-Type": "application/json",
             });
@@ -25,10 +26,11 @@ describe("Browser", function () {
             expect(body).toEqual({
                 response: "default 404 - @forsakringskassan/apimock-express",
             });
-            expect(response.status).toEqual(404);
+            expect(response.status).toBe(404);
         });
 
-        test("Should get specific post request", async () => {
+        it("should get specific post request", async () => {
+            expect.assertions(2);
             const response = await getMockResponse(
                 "/private/foo/basic?foo=bar",
                 "POST",
@@ -38,10 +40,11 @@ describe("Browser", function () {
             expect(body).toEqual({
                 post: "bar",
             });
-            expect(response.status).toEqual(200);
+            expect(response.status).toBe(200);
         });
 
-        test("Should be able to find mocks based on cookies", async () => {
+        it("should be able to find mocks based on cookies", async () => {
+            expect.assertions(1);
             vi.spyOn(document, "cookie", "get").mockImplementation(
                 () => "foo=bar",
             );
@@ -52,9 +55,11 @@ describe("Browser", function () {
             );
 
             const body = await response.text();
-            expect(body).toEqual("cookies");
+            expect(body).toBe("cookies");
         });
-        test("should be able to save multiple binary blob text", async () => {
+
+        it("should be able to save multiple binary blob text", async () => {
+            expect.assertions(1);
             const abc = new Blob(["Apimock"], { type: "text/plain" });
             const formData = new FormData();
             formData.append("text", abc, "text.txt");

--- a/test/browser/match-response-browser.spec.mjs
+++ b/test/browser/match-response-browser.spec.mjs
@@ -1,14 +1,14 @@
 // @vitest-environment happy-dom
 /* global document */
 
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { matchResponseBrowser } from "../../src/browser";
 import advancedGetMock from "../api/js/body-fn.mjs";
 import advancedPostMock from "../api/js/body-fn_post.mjs";
 import basicMockPost from "./basic-mock-post.mjs";
 import basicMock from "./basic-mock.mjs";
 
-describe("Browser", function () {
+describe("browser", function () {
     describe("matchResponseBrowser", function () {
         const config = {
             mockdata: [
@@ -23,7 +23,8 @@ describe("Browser", function () {
             headers: undefined,
         };
 
-        test("Should return 404 response if no match", async () => {
+        it("should return 404 response if no match", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
                 requestUrl: "404",
@@ -40,7 +41,8 @@ describe("Browser", function () {
             });
         });
 
-        test("Should be able to send in full url", async () => {
+        it("should be able to send in full url", async () => {
+            expect.assertions(2);
             const customConfig = {
                 ...config,
                 requestUrl: "https://example.net/private/foo/basic?foo=bar",
@@ -61,7 +63,8 @@ describe("Browser", function () {
             });
         });
 
-        test("Should get default GET-response", async () => {
+        it("should get default GET-response", async () => {
+            expect.assertions(1);
             const response = matchResponseBrowser(config);
             expect(response).to.deep.equal({
                 body: { foo: "bar" },
@@ -70,7 +73,8 @@ describe("Browser", function () {
             });
         });
 
-        test("Should be able to find mocks based on cookies", async () => {
+        it("should be able to find mocks based on cookies", async () => {
+            expect.assertions(1);
             vi.spyOn(document, "cookie", "get").mockImplementation(
                 () => "foo=bar",
             );
@@ -82,7 +86,8 @@ describe("Browser", function () {
             });
         });
 
-        test("Should be able to find mocks query params", async () => {
+        it("should be able to find mocks query params", async () => {
+            expect.assertions(1);
             const customConfig = {
                 ...config,
                 requestUrl: "/private/foo/basic?bar=foo&foo=bar",
@@ -95,8 +100,9 @@ describe("Browser", function () {
             });
         });
 
-        describe("Mock saving values to a global state", () => {
-            test("should get default value when no data saved", async () => {
+        describe("mock saving values to a global state", () => {
+            it("should get default value when no data saved", async () => {
+                expect.assertions(1);
                 const customConfig = {
                     ...config,
                     requestUrl: "/advanced/reading-mock",
@@ -109,7 +115,8 @@ describe("Browser", function () {
                 });
             });
 
-            test("should be able to post data and then retrieve the value", async () => {
+            it("should be able to post data and then retrieve the value", async () => {
+                expect.assertions(1);
                 let customConfig = {
                     ...config,
                     requestUrl: "/advanced/post-mock",

--- a/test/commontest/advanced-mockformat-bodyparameter.spec.mjs
+++ b/test/commontest/advanced-mockformat-bodyparameter.spec.mjs
@@ -1,10 +1,11 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Advanced mockformat", function () {
-    describe("Bodyparameter", function () {
-        test("Should return the response for the first bodyparamter match", async () => {
+describe("advanced mockformat", function () {
+    describe("bodyparameter", function () {
+        it("should return the response for the first bodyparamter match", async () => {
+            expect.assertions(3);
             const requestbody = { foo: "foo" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter`,
@@ -22,7 +23,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foo" });
         });
 
-        test("Should return the response for the second bodyparamter match", async () => {
+        it("should return the response for the second bodyparamter match", async () => {
+            expect.assertions(3);
             const requestbody = { foo: "bar" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter`,
@@ -40,7 +42,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "bar" });
         });
 
-        test("Should return the default response if no match in bodyparameter value", async () => {
+        it("should return the default response if no match in bodyparameter value", async () => {
+            expect.assertions(3);
             const requestbody = { foo: "asdf" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter`,
@@ -58,7 +61,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return the default response if no match in bodyparameter name", async () => {
+        it("should return the default response if no match in bodyparameter name", async () => {
+            expect.assertions(3);
             const requestbody = { bar: "asdf" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter`,
@@ -76,7 +80,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return an error if no match and no default response", async () => {
+        it("should return an error if no match and no default response", async () => {
+            expect.assertions(3);
             const requestbody = { foo: "asdf" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter_no_defaultresponse`,
@@ -96,7 +101,8 @@ describe("Advanced mockformat", function () {
             });
         });
 
-        test("Should return the default response if no bodyparameters in mockfile", async () => {
+        it("should return the default response if no bodyparameters in mockfile", async () => {
+            expect.assertions(3);
             const requestbody = { foo: "bar" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter_no_parameters`,
@@ -115,8 +121,9 @@ describe("Advanced mockformat", function () {
         });
     });
 
-    describe("Complex Bodyparameter", function () {
-        test("Should match two parameters on second level", async () => {
+    describe("complex Bodyparameter", function () {
+        it("should match two parameters on second level", async () => {
+            expect.assertions(3);
             const requestbody = {
                 user: {
                     firstname: "Luke",
@@ -143,7 +150,8 @@ describe("Advanced mockformat", function () {
             });
         });
 
-        test("Should match one parameter on second level", async () => {
+        it("should match one parameter on second level", async () => {
+            expect.assertions(3);
             const requestbody = {
                 user: {
                     firstname: "Luke",
@@ -170,7 +178,8 @@ describe("Advanced mockformat", function () {
             });
         });
 
-        test("Should match one parameter on third level", async () => {
+        it("should match one parameter on third level", async () => {
+            expect.assertions(3);
             const requestbody = {
                 user: {
                     firstname: "Zeb",
@@ -197,7 +206,8 @@ describe("Advanced mockformat", function () {
             });
         });
 
-        test("Should match one parameter on first level", async () => {
+        it("should match one parameter on first level", async () => {
+            expect.assertions(3);
             const requestbody = {
                 user: {
                     firstname: "Zeb",
@@ -224,7 +234,8 @@ describe("Advanced mockformat", function () {
             });
         });
 
-        test("Should handle a request that do not contain all of the mock parameters", async () => {
+        it("should handle a request that do not contain all of the mock parameters", async () => {
+            expect.assertions(3);
             const requestbody = { foo: "bar" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter_complex_body`,
@@ -244,7 +255,8 @@ describe("Advanced mockformat", function () {
             });
         });
 
-        test("Should return the default answer if no match", async () => {
+        it("should return the default answer if no match", async () => {
+            expect.assertions(3);
             const requestbody = { asdf: "asdf" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter_complex_body`,
@@ -265,8 +277,9 @@ describe("Advanced mockformat", function () {
         });
     });
 
-    describe("Bodyparameters", function () {
-        test("Should return the default answer if only one of two bodyparameters matches", async () => {
+    describe("bodyparameters", function () {
+        it("should return the default answer if only one of two bodyparameters matches", async () => {
+            expect.assertions(3);
             const requestbody = { foo: "bar" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameters`,
@@ -284,7 +297,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return the answer for both bodyparameters match", async () => {
+        it("should return the answer for both bodyparameters match", async () => {
+            expect.assertions(3);
             const requestbody = { foo: "bar", bar: "foo" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameters`,
@@ -303,8 +317,9 @@ describe("Advanced mockformat", function () {
         });
     });
 
-    describe("Bodyparameter and requestparameter", function () {
-        test("Should return the default answer if only the requestparameter matches", async () => {
+    describe("bodyparameter and requestparameter", function () {
+        it("should return the default answer if only the requestparameter matches", async () => {
+            expect.assertions(3);
             const requestbody = { asdf: "asdf" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter_bodyparameter?foo=bar`,
@@ -322,7 +337,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return the default answer if only the bodyparameter matches", async () => {
+        it("should return the default answer if only the bodyparameter matches", async () => {
+            expect.assertions(3);
             const requestbody = { bar: "foo" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter_bodyparameter?asdf=asdf`,
@@ -340,7 +356,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return the answer for requestparameter and bodyparameter match", async () => {
+        it("should return the answer for requestparameter and bodyparameter match", async () => {
+            expect.assertions(3);
             const requestbody = { bar: "foo" };
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter_bodyparameter?foo=bar`,

--- a/test/commontest/advanced-mockformat-cookie.spec.mjs
+++ b/test/commontest/advanced-mockformat-cookie.spec.mjs
@@ -1,10 +1,11 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Advanced mockformat", function () {
-    describe("Cookies", function () {
-        test("Should return the response for the first cookie match", async () => {
+describe("advanced mockformat", function () {
+    describe("cookies", function () {
+        it("should return the response for the first cookie match", async () => {
+            expect.assertions(3);
             const headers = {
                 Cookie: "foo=foo",
             };
@@ -20,7 +21,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foo" });
         });
 
-        test("Should return the response for the second cookie match", async () => {
+        it("should return the response for the second cookie match", async () => {
+            expect.assertions(3);
             const headers = {
                 Cookie: "foo=bar",
             };
@@ -36,7 +38,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "bar" });
         });
 
-        test("Should return the default response if no match", async () => {
+        it("should return the default response if no match", async () => {
+            expect.assertions(3);
             const headers = {
                 Cookie: "asdf=asdf",
             };
@@ -52,7 +55,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return the default response if no cookies in mockfile", async () => {
+        it("should return the default response if no cookies in mockfile", async () => {
+            expect.assertions(3);
             const headers = {
                 Cookie: "foo=foo",
             };
@@ -71,7 +75,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return the default response if no cookies in request", async () => {
+        it("should return the default response if no cookies in request", async () => {
+            expect.assertions(3);
             const headers = {};
             const res = await fetch(`http://${hostname}/api/advanced/cookie`, {
                 method: "get",

--- a/test/commontest/advanced-mockformat-delay.spec.mjs
+++ b/test/commontest/advanced-mockformat-delay.spec.mjs
@@ -1,12 +1,13 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Advanced mockformat", function () {
+describe("advanced mockformat", function () {
     const DELAY_TIME = 1000;
 
-    describe("Delay", function () {
-        test("GET /api/advanced/delay?foo=bar should not be delayed", async () => {
+    describe("delay", function () {
+        it("get /api/advanced/delay?foo=bar should not be delayed", async () => {
+            expect.assertions(3);
             const starttime = Date.now();
             const res = await fetch(
                 `http://${hostname}/api/advanced/delay?foo=bar`,
@@ -19,7 +20,8 @@ describe("Advanced mockformat", function () {
             expect(executionTime).to.be.at.most(DELAY_TIME);
         });
 
-        test("GET /api/advanced/delay?foo=foo should be delayed", async () => {
+        it("get /api/advanced/delay?foo=foo should be delayed", async () => {
+            expect.assertions(3);
             const starttime = Date.now();
             const res = await fetch(
                 `http://${hostname}/api/advanced/delay?foo=foo`,

--- a/test/commontest/advanced-mockformat-errors.spec.mjs
+++ b/test/commontest/advanced-mockformat-errors.spec.mjs
@@ -1,10 +1,11 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Advanced mockformat", function () {
-    describe("Errors", function () {
-        test("Should return the default response if only default response", async () => {
+describe("advanced mockformat", function () {
+    describe("errors", function () {
+        it("should return the default response if only default response", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/only_defaultresponse`,
                 { method: "get" },
@@ -17,7 +18,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return an empty string if no body in only default response", async () => {
+        it("should return an empty string if no body in only default response", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/only_defaultresponse_no_body`,
                 { method: "get" },
@@ -30,7 +32,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.equal("");
         });
 
-        test("Should return the default status if no status in only default response", async () => {
+        it("should return the default status if no status in only default response", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/only_defaultresponse_no_status`,
                 { method: "get" },
@@ -43,7 +46,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return an error if the file is malformed", async () => {
+        it("should return an error if the file is malformed", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/malformedfile`,
                 { method: "get" },
@@ -58,7 +62,8 @@ describe("Advanced mockformat", function () {
             });
         });
 
-        test("Should return an error if the input body is malformed", async () => {
+        it("should return an error if the input body is malformed", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter`,
                 {
@@ -77,7 +82,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ error: "Malformed input body" });
         });
 
-        test("Should not parse the body, but return the default response if input body is not json", async () => {
+        it("should not parse the body, but return the default response if input body is not json", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/bodyparameter`,
                 {

--- a/test/commontest/advanced-mockformat-headers.spec.mjs
+++ b/test/commontest/advanced-mockformat-headers.spec.mjs
@@ -1,10 +1,11 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Advanced mockformat", function () {
-    describe("Headers", function () {
-        test("Should return the second response if one matches", async () => {
+describe("advanced mockformat", function () {
+    describe("headers", function () {
+        it("should return the second response if one matches", async () => {
+            expect.assertions(3);
             const headers = {
                 header1: "one",
                 header2: "2",
@@ -21,7 +22,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "one" });
         });
 
-        test("Should return the first response if both matches", async () => {
+        it("should return the first response if both matches", async () => {
+            expect.assertions(3);
             const headers = {
                 header1: "one",
                 header2: "two",
@@ -38,7 +40,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "onetwo" });
         });
 
-        test("Should return the first response if two of three matches", async () => {
+        it("should return the first response if two of three matches", async () => {
+            expect.assertions(3);
             const headers = {
                 header1: "one",
                 header2: "two",
@@ -56,7 +59,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "onetwo" });
         });
 
-        test("Should return the default response if no matches", async () => {
+        it("should return the default response if no matches", async () => {
+            expect.assertions(3);
             const headers = {
                 header1: "foo",
                 header2: "bar",

--- a/test/commontest/advanced-mockformat-requestparameter.spec.mjs
+++ b/test/commontest/advanced-mockformat-requestparameter.spec.mjs
@@ -1,10 +1,11 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Advanced mockformat", function () {
-    describe("Requestparameter", function () {
-        test("Should return the response for the first requestparameter match", async () => {
+describe("advanced mockformat", function () {
+    describe("requestparameter", function () {
+        it("should return the response for the first requestparameter match", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter?foo=foo`,
                 { method: "get" },
@@ -17,7 +18,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foo" });
         });
 
-        test("Should return the response for the second requestparameter match", async () => {
+        it("should return the response for the second requestparameter match", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter?foo=bar`,
                 { method: "get" },
@@ -30,7 +32,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "bar" });
         });
 
-        test("Should return the default response if no match in requestparameter value", async () => {
+        it("should return the default response if no match in requestparameter value", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter?foo=asdf`,
                 { method: "get" },
@@ -43,7 +46,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return the default response if no match in requestparameter name", async () => {
+        it("should return the default response if no match in requestparameter name", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter?bar=asdf`,
                 { method: "get" },
@@ -56,7 +60,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return an error if no match and no default response", async () => {
+        it("should return an error if no match and no default response", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter_no_defaultresponse`,
                 { method: "get" },
@@ -69,7 +74,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ error: "No response could be found" });
         });
 
-        test("Should return the default response if no requestparameters in mockfile", async () => {
+        it("should return the default response if no requestparameters in mockfile", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameter_no_parameters`,
                 { method: "get" },
@@ -83,8 +89,9 @@ describe("Advanced mockformat", function () {
         });
     });
 
-    describe("Requestparameters", function () {
-        test("Should return the default response if only one of two requestparameters matches", async () => {
+    describe("requestparameters", function () {
+        it("should return the default response if only one of two requestparameters matches", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameters?foo=bar`,
                 { method: "get" },
@@ -97,7 +104,8 @@ describe("Advanced mockformat", function () {
             expect(body).to.deep.equal({ message: "foofoofoo" });
         });
 
-        test("Should return the answer for both requestparameters match", async () => {
+        it("should return the answer for both requestparameters match", async () => {
+            expect.assertions(3);
             const res = await fetch(
                 `http://${hostname}/api/advanced/requestparameters?foo=bar&bar=foo`,
                 { method: "get" },

--- a/test/commontest/advanced-mockformat-response-header.spec.mjs
+++ b/test/commontest/advanced-mockformat-response-header.spec.mjs
@@ -1,10 +1,11 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Advanced mockformat", function () {
-    describe("Headers", function () {
-        test("POST /headers/sign should respond with 302 redirect", async () => {
+describe("advanced mockformat", function () {
+    describe("headers", function () {
+        it("post /headers/sign should respond with 302 redirect", async () => {
+            expect.assertions(2);
             const res = await fetch(`http://${hostname}/headers/redirect`, {
                 method: "post",
                 redirect: "manual",

--- a/test/commontest/examplefile.spec.mjs
+++ b/test/commontest/examplefile.spec.mjs
@@ -1,9 +1,10 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Examplefile", function () {
-    test("Nothing matches", async () => {
+describe("examplefile", function () {
+    it("nothing matches", async () => {
+        expect.assertions(2);
         const requestbody = {};
         const res = await fetch(`http://${hostname}/api/examplefile`, {
             method: "post",
@@ -19,7 +20,8 @@ describe("Examplefile", function () {
         });
     });
 
-    test("One request parameter matches", async () => {
+    it("one request parameter matches", async () => {
+        expect.assertions(2);
         const requestbody = {};
         const res = await fetch(`http://${hostname}/api/examplefile?foo=bar`, {
             method: "post",
@@ -35,7 +37,8 @@ describe("Examplefile", function () {
         });
     });
 
-    test("Two request parameters matches", async () => {
+    it("two request parameters matches", async () => {
+        expect.assertions(2);
         const requestbody = {};
         const res = await fetch(
             `http://${hostname}/api/examplefile?foo=bar&bar=foo`,
@@ -54,7 +57,8 @@ describe("Examplefile", function () {
         });
     });
 
-    test("One body parameter matches", async () => {
+    it("one body parameter matches", async () => {
+        expect.assertions(2);
         const requestbody = { foo: "foo" };
         const res = await fetch(`http://${hostname}/api/examplefile`, {
             method: "post",
@@ -70,7 +74,8 @@ describe("Examplefile", function () {
         });
     });
 
-    test("Two body parameters matches", async () => {
+    it("two body parameters matches", async () => {
+        expect.assertions(2);
         const requestbody = {
             user: { firstname: "Luke", lastname: "Skywalker" },
         };
@@ -88,7 +93,8 @@ describe("Examplefile", function () {
         });
     });
 
-    test("Both request parameter and body matches", async () => {
+    it("both request parameter and body matches", async () => {
+        expect.assertions(2);
         const requestbody = { bar: "foo" };
         const res = await fetch(`http://${hostname}/api/examplefile?foo=bar`, {
             method: "post",
@@ -104,7 +110,8 @@ describe("Examplefile", function () {
         });
     });
 
-    test("One body parameter matches. Default status", async () => {
+    it("one body parameter matches. Default status", async () => {
+        expect.assertions(2);
         const requestbody = { foo: "bar" };
         const res = await fetch(`http://${hostname}/api/examplefile`, {
             method: "post",

--- a/test/commontest/interceptor.spec.mjs
+++ b/test/commontest/interceptor.spec.mjs
@@ -1,9 +1,10 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Intercepted call", function () {
-    test("Should handle when an earlier middleware intercepts request body", async () => {
+describe("intercepted call", function () {
+    it("should handle when an earlier middleware intercepts request body", async () => {
+        expect.assertions(2);
         const res = await fetch(`http://${hostname}/api/intercepted`, {
             method: "get",
         });

--- a/test/commontest/js.spec.mjs
+++ b/test/commontest/js.spec.mjs
@@ -1,9 +1,10 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
 describe("js mocks", function () {
-    test("plain file", async () => {
+    it("plain file", async () => {
+        expect.assertions(2);
         const requestbody = {};
         const res = await fetch(`http://${hostname}/api/js/file`, {
             method: "post",
@@ -19,7 +20,8 @@ describe("js mocks", function () {
         });
     });
 
-    test("default export", async () => {
+    it("default export", async () => {
+        expect.assertions(2);
         const requestbody = {};
         const res = await fetch(`http://${hostname}/api/js/default-export`, {
             method: "post",
@@ -35,13 +37,15 @@ describe("js mocks", function () {
         });
     });
 
-    test("remove relativ path for error message, file not found", () => {
+    it("remove relativ path for error message, file not found", () => {
+        expect.assertions(1);
         expect("../../app/private/../v1".replace(/^(?:\.\.\/)+/, "")).to.equal(
             "app/private/../v1",
         );
     });
 
-    test("commonjs file (.cjs)", async () => {
+    it("commonjs file (.cjs)", async () => {
+        expect.assertions(1);
         const res = await fetch(`http://${hostname}/api/js/commonjs`, {
             method: "get",
             headers: {
@@ -54,7 +58,8 @@ describe("js mocks", function () {
         });
     });
 
-    test("esm file (.mjs)", async () => {
+    it("esm file (.mjs)", async () => {
+        expect.assertions(1);
         const res = await fetch(`http://${hostname}/api/js/esm`, {
             method: "get",
             headers: {
@@ -67,8 +72,9 @@ describe("js mocks", function () {
         });
     });
 
-    describe("Mock saving values to a global state", () => {
-        test("should get default value when no data saved", async () => {
+    describe("mock saving values to a global state", () => {
+        it("should get default value when no data saved", async () => {
+            expect.assertions(1);
             const res = await fetch(`http://${hostname}/api/js/body-fn`, {
                 method: "get",
             });
@@ -78,7 +84,8 @@ describe("js mocks", function () {
             });
         });
 
-        test("should be able to post data and then retrieve the value", async () => {
+        it("should be able to post data and then retrieve the value", async () => {
+            expect.assertions(1);
             await fetch(`http://${hostname}/api/js/body-fn`, {
                 method: "post",
                 headers: {
@@ -110,7 +117,8 @@ describe("js mocks", function () {
             });
         });
 
-        test("saving plain text", async () => {
+        it("saving plain text", async () => {
+            expect.assertions(1);
             await fetch(`http://${hostname}/api/js/body-fn`, {
                 method: "post",
                 headers: {
@@ -130,7 +138,8 @@ describe("js mocks", function () {
             expect(body).to.deep.equal("plain text to the rescue");
         });
 
-        test("saving a binary blob text", async () => {
+        it("saving a binary blob text", async () => {
+            expect.assertions(1);
             const abc = new Blob(["Apimock"], { type: "text/plain" });
             const formData = new FormData();
             formData.append("text", abc, "text.txt");
@@ -157,7 +166,8 @@ describe("js mocks", function () {
             ]);
         });
 
-        test("saving multiple binary blob text", async () => {
+        it("saving multiple binary blob text", async () => {
+            expect.assertions(1);
             const abc = new Blob(["Apimock"], { type: "text/plain" });
             const formData = new FormData();
             formData.append("text", abc, "text.txt");
@@ -190,7 +200,8 @@ describe("js mocks", function () {
             ]);
         });
 
-        test("reqeust function", async () => {
+        it("reqeust function", async () => {
+            expect.assertions(1);
             const res = await fetch(`http://${hostname}/api/js/request-fn`, {
                 method: "get",
                 headers: {
@@ -205,7 +216,8 @@ describe("js mocks", function () {
     });
 
     // Invalid format, which we still need to support
-    test("should support invalid format where mock returns a string instead of object", async () => {
+    it("should support invalid format where mock returns a string instead of object", async () => {
+        expect.assertions(1);
         const res = await fetch(`http://${hostname}/api/js/invalid-stringify`);
 
         expect(await res.json()).to.deep.equal({
@@ -213,7 +225,8 @@ describe("js mocks", function () {
         });
     });
 
-    test("should support response as function", async () => {
+    it("should support response as function", async () => {
+        expect.assertions(2);
         const res = await fetch(`http://${hostname}/api/js/response-function`, {
             method: "post",
             headers: {
@@ -226,7 +239,8 @@ describe("js mocks", function () {
     });
 
     describe("request parameters", () => {
-        test("should pass empty object to response function when there are no parameters in url", async () => {
+        it("should pass empty object to response function when there are no parameters in url", async () => {
+            expect.assertions(2);
             const res = await fetch(
                 `http://${hostname}/api/js/response-function`,
             );
@@ -235,7 +249,8 @@ describe("js mocks", function () {
             expect(jsonRes.parameters).to.deep.equal({});
         });
 
-        test("should pass object to response function when there is a single parameter in url", async () => {
+        it("should pass object to response function when there is a single parameter in url", async () => {
+            expect.assertions(2);
             const res = await fetch(
                 `http://${hostname}/api/js/response-function?foo=foolish`,
             );
@@ -246,7 +261,8 @@ describe("js mocks", function () {
             });
         });
 
-        test("should pass object to response function when there are multiple parameters in url", async () => {
+        it("should pass object to response function when there are multiple parameters in url", async () => {
+            expect.assertions(2);
             const res = await fetch(
                 `http://${hostname}/api/js/response-function?foo=foolish&bar=barish`,
             );
@@ -258,7 +274,8 @@ describe("js mocks", function () {
             });
         });
 
-        test("should pass object to response function when there is an encoded parameter in url", async () => {
+        it("should pass object to response function when there is an encoded parameter in url", async () => {
+            expect.assertions(2);
             const res = await fetch(
                 `http://${hostname}/api/js/response-function?foo=foolish%20value`,
             );
@@ -269,7 +286,8 @@ describe("js mocks", function () {
             });
         });
 
-        test("should pass object to response function when there is a parameter without value", async () => {
+        it("should pass object to response function when there is a parameter without value", async () => {
+            expect.assertions(2);
             const res = await fetch(
                 `http://${hostname}/api/js/response-function?foo`,
             );

--- a/test/commontest/simple-mockformat.spec.mjs
+++ b/test/commontest/simple-mockformat.spec.mjs
@@ -1,10 +1,11 @@
 import fs from "node:fs";
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Simple mockformat", function () {
-    test("GET /api/simple/users/ should return test/api/simple/users.json", async () => {
+describe("simple mockformat", function () {
+    it("get /api/simple/users/ should return test/api/simple/users.json", async () => {
+        expect.assertions(3);
         const expectedBody = fs.readFileSync("test/api/simple/users.json", {
             encoding: "utf8",
         });
@@ -19,7 +20,8 @@ describe("Simple mockformat", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("GET /api/simple/users/1 should return test/api/simple/users/1.json", async () => {
+    it("get /api/simple/users/1 should return test/api/simple/users/1.json", async () => {
+        expect.assertions(3);
         const expectedBody = fs.readFileSync("test/api/simple/users/1.json", {
             encoding: "utf8",
         });
@@ -34,7 +36,8 @@ describe("Simple mockformat", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("POST /api/simple/users/ should return test/api/simple/users_post.json", async () => {
+    it("post /api/simple/users/ should return test/api/simple/users_post.json", async () => {
+        expect.assertions(3);
         const expectedBody = fs.readFileSync(
             "test/api/simple/users_post.json",
             {
@@ -52,7 +55,8 @@ describe("Simple mockformat", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("PUT /api/simple/users/ should return test/api/simple/users/1_put.json", async () => {
+    it("put /api/simple/users/ should return test/api/simple/users/1_put.json", async () => {
+        expect.assertions(3);
         const expectedBody = fs.readFileSync(
             "test/api/simple/users/1_put.json",
             {
@@ -70,7 +74,8 @@ describe("Simple mockformat", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("DELETE /api/simple/users/ should return test/api/simple/users/1_delete.json", async () => {
+    it("delete /api/simple/users/ should return test/api/simple/users/1_delete.json", async () => {
+        expect.assertions(3);
         const expectedBody = fs.readFileSync(
             "test/api/simple/users/1_delete.json",
             { encoding: "utf8" },
@@ -86,7 +91,8 @@ describe("Simple mockformat", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("path not found should return an error", async () => {
+    it("path not found should return an error", async () => {
+        expect.assertions(3);
         const expectedBody = "Error: Cannot find file matching glob";
         const res = await fetch(`http://${hostname}/api/simple/users/1234`, {
             method: "get",
@@ -99,7 +105,8 @@ describe("Simple mockformat", function () {
         expect(body).to.have.string(expectedBody);
     });
 
-    test("GET /api/apiX should get find file in apiX-folder", async () => {
+    it("get /api/apiX should get find file in apiX-folder", async () => {
+        expect.assertions(3);
         const res = await fetch(`http://${hostname}/api/apiX`, {
             method: "get",
         });
@@ -111,7 +118,8 @@ describe("Simple mockformat", function () {
         expect(body).to.deep.equal({ id: "apiX" });
     });
 
-    test("GET /api/dir/ should return test/api/dir/__get.json", async () => {
+    it("get /api/dir/ should return test/api/dir/__get.json", async () => {
+        expect.assertions(3);
         const expectedBody = fs.readFileSync("test/api/dir/__get.json", {
             encoding: "utf8",
         });
@@ -126,7 +134,8 @@ describe("Simple mockformat", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("POST /api/dir/ should return test/api/dir/__post.json", async () => {
+    it("post /api/dir/ should return test/api/dir/__post.json", async () => {
+        expect.assertions(3);
         const expectedBody = fs.readFileSync("test/api/dir/__post.json", {
             encoding: "utf8",
         });

--- a/test/commontest/urlmatching.spec.mjs
+++ b/test/commontest/urlmatching.spec.mjs
@@ -1,10 +1,11 @@
 import fs from "node:fs";
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Url matching", function () {
-    test("A correct url that starts with mock url should match", async () => {
+describe("url matching", function () {
+    it("a correct url that starts with mock url should match", async () => {
+        expect.assertions(2);
         const expectedBody = fs.readFileSync("test/api/simple/users.json", {
             encoding: "utf8",
         });
@@ -16,7 +17,8 @@ describe("Url matching", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("Must start with the mock url", async () => {
+    it("must start with the mock url", async () => {
+        expect.assertions(2);
         //The url matches but not in the beginning
         const expectedBody = "Cannot GET /foo/api/simple/users/";
         const res = await fetch(`http://${hostname}/foo/api/simple/users/`, {
@@ -27,7 +29,8 @@ describe("Url matching", function () {
         expect(body).to.have.string(expectedBody);
     });
 
-    test("A incorrect url should not match", async () => {
+    it("a incorrect url should not match", async () => {
+        expect.assertions(2);
         const expectedBody = "Cannot GET /foo/simple/users/";
         const res = await fetch(`http://${hostname}/foo/simple/users/`, {
             method: "get",

--- a/test/commontest/wildcard.spec.mjs
+++ b/test/commontest/wildcard.spec.mjs
@@ -1,9 +1,10 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Wildcard", function () {
-    test("should pick wildcard file for GET if specific not found", async () => {
+describe("wildcard", function () {
+    it("should pick wildcard file for GET if specific not found", async () => {
+        expect.assertions(2);
         const res = await fetch(`http://${hostname}/api/wildcard/123`, {
             method: "get",
         });
@@ -12,7 +13,8 @@ describe("Wildcard", function () {
         expect(body).to.deep.equal({ message: "Wildcard GET" });
     });
 
-    test("should pick wildcard file for POST if specific not found", async () => {
+    it("should pick wildcard file for POST if specific not found", async () => {
+        expect.assertions(2);
         const requestbody = {};
         const res = await fetch(`http://${hostname}/api/wildcard/123`, {
             method: "post",

--- a/test/paths/paths.spec.mjs
+++ b/test/paths/paths.spec.mjs
@@ -1,4 +1,4 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
@@ -11,7 +11,8 @@ function normalizePath(value) {
 }
 
 describe("relative path mocks", function () {
-    test("GET - should find json file", async () => {
+    it("get - should find json file", async () => {
+        expect.assertions(1);
         const res = await fetch(
             `http://${hostname}/relative-path/endpoint-json`,
             { method: "get" },
@@ -19,7 +20,8 @@ describe("relative path mocks", function () {
         expect(res.status).to.equal(200);
     });
 
-    test("GET - should find js file", async () => {
+    it("get - should find js file", async () => {
+        expect.assertions(1);
         const res = await fetch(
             `http://${hostname}/relative-path/endpoint-js`,
             { method: "get" },
@@ -27,7 +29,8 @@ describe("relative path mocks", function () {
         expect(res.status).to.equal(200);
     });
 
-    test("GET - should handle missing file", async () => {
+    it("get - should handle missing file", async () => {
+        expect.assertions(2);
         const res = await fetch(`http://${hostname}/absolute-path/missing`, {
             method: "get",
         });
@@ -40,7 +43,8 @@ describe("relative path mocks", function () {
 });
 
 describe("absolute path mocks", function () {
-    test("GET - should find json file", async () => {
+    it("get - should find json file", async () => {
+        expect.assertions(1);
         const res = await fetch(
             `http://${hostname}/absolute-path/endpoint-json`,
             { method: "get" },
@@ -48,7 +52,8 @@ describe("absolute path mocks", function () {
         expect(res.status).to.equal(200);
     });
 
-    test("GET - should find js file", async () => {
+    it("get - should find js file", async () => {
+        expect.assertions(1);
         const res = await fetch(
             `http://${hostname}/absolute-path/endpoint-js`,
             { method: "get" },
@@ -56,7 +61,8 @@ describe("absolute path mocks", function () {
         expect(res.status).to.equal(200);
     });
 
-    test("GET - should handle missing file", async () => {
+    it("get - should handle missing file", async () => {
+        expect.assertions(2);
         const res = await fetch(`http://${hostname}/absolute-path/missing`, {
             method: "get",
         });

--- a/test/targetconfigtest/basedelay.spec.mjs
+++ b/test/targetconfigtest/basedelay.spec.mjs
@@ -1,12 +1,13 @@
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Basedelay", function () {
+describe("basedelay", function () {
     const DELAY_TIME = 1000;
 
     describe("simple mockformat", function () {
-        test("GET /api2/hello should not be delayed", async () => {
+        it("get /api2/hello should not be delayed", async () => {
+            expect.assertions(3);
             const starttime = Date.now();
             const expectedBody = { id: "api" };
             const res = await fetch(`http://${hostname}/api2/hello`, {
@@ -20,7 +21,8 @@ describe("Basedelay", function () {
             expect(executionTime).to.be.at.most(DELAY_TIME);
         });
 
-        test("GET /apiX/hello should be delayed", async () => {
+        it("get /apiX/hello should be delayed", async () => {
+            expect.assertions(3);
             const starttime = Date.now();
             const expectedBody = { id: "apiX" };
             const res = await fetch(`http://${hostname}/apiX/hello`, {
@@ -36,7 +38,8 @@ describe("Basedelay", function () {
     });
 
     describe("advanced mockformat", function () {
-        test("GET /api2/helloAdv should not be delayed", async () => {
+        it("get /api2/helloAdv should not be delayed", async () => {
+            expect.assertions(3);
             const starttime = Date.now();
             const expectedBody = { id: "api" };
             const res = await fetch(`http://${hostname}/api2/helloAdv`, {
@@ -50,7 +53,8 @@ describe("Basedelay", function () {
             expect(executionTime).to.be.at.most(DELAY_TIME);
         });
 
-        test("GET /apiX/helloAdv should be delayed", async () => {
+        it("get /apiX/helloAdv should be delayed", async () => {
+            expect.assertions(3);
             const starttime = Date.now();
             const expectedBody = { id: "apiX" };
             const res = await fetch(`http://${hostname}/apiX/helloAdv`, {

--- a/test/targetconfigtest/multiconfig.spec.mjs
+++ b/test/targetconfigtest/multiconfig.spec.mjs
@@ -1,10 +1,11 @@
 import fs from "node:fs";
-import { describe, expect, inject, test } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 
 const hostname = inject("hostname");
 
-describe("Multiconfig", function () {
-    test("Local config GET /api2/simple/users/ should return test/api/simple/users.json", async () => {
+describe("multiconfig", function () {
+    it("local config GET /api2/simple/users/ should return test/api/simple/users.json", async () => {
+        expect.assertions(2);
         const expectedBody = fs.readFileSync("test/api/simple/users.json", {
             encoding: "utf8",
         });
@@ -16,7 +17,8 @@ describe("Multiconfig", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("Multiple config GET /api2/hello should return test/api/hello.json", async () => {
+    it("multiple config GET /api2/hello should return test/api/hello.json", async () => {
+        expect.assertions(2);
         const expectedBody = '{ "id": "api" }\n';
         const res = await fetch(`http://${hostname}/api2/hello`, {
             method: "get",
@@ -26,7 +28,8 @@ describe("Multiconfig", function () {
         expect(body).to.deep.equal(JSON.parse(expectedBody));
     });
 
-    test("Multiple config GET /apiX/hello should return test/apiX/hello.json", async () => {
+    it("multiple config GET /apiX/hello should return test/apiX/hello.json", async () => {
+        expect.assertions(2);
         const expectedBody = '{ "id": "apiX" }\n';
         const res = await fetch(`http://${hostname}/apiX/hello`, {
             method: "get",


### PR DESCRIPTION
Kört `npm run eslint:fix` för att rätta ut de fel som går per automagi, sen lät jag copilot köra igenom alla tester och peta dit `expect.assertions(n)` för samtliga tester.