### PR TITLE
refactor: move creation of url path into generate-for-browser

### DIFF
--- a/src/node/extract-file-content.ts
+++ b/src/node/extract-file-content.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path/posix";
-import url from "node:url";
 
 import { type Mock } from "../mockfile";
 
@@ -32,9 +31,7 @@ export async function extractFileContent(filepath: string): Promise<Mock> {
         case ".js":
         case ".cjs":
         case ".mjs": {
-            let { default: mock } = (await import(
-                url.pathToFileURL(filepath).toString()
-            )) as {
+            let { default: mock } = (await import(filepath)) as {
                 default: Mock | { default: Mock };
             };
 


### PR DESCRIPTION
`url.pathToFileURL` was added into extractFileContent due to window related issues, but it is more appropriate to do this in generate-for-browser, as the url path is only needed there.

Sadly, i did not add any unit tests for this in previous pr.
* https://github.com/Forsakringskassan/apimock-express/pull/70/commits