### PR TITLE
fix: matchRequest should support delay config

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,6 +1,6 @@
 import { getCookies } from "./browser/get-cookies";
 import { getRequestParamsFromUrl } from "./browser/get-request-params-from-url";
-import { selectResponse } from "./common";
+import { parseDelay, selectResponse } from "./common";
 import {
     type Mock,
     type MockResponse,
@@ -54,6 +54,11 @@ export async function matchRequest(
         headers,
     };
     const mockResponse = matchResponseBrowser(options) as StaticMockResponse;
+
+    const delay = parseDelay(mockResponse.delay);
+    if (delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+    }
 
     const fetchOptions: ResponseInit = {
         status: mockResponse.status,

--- a/test/api/js/delay.mjs
+++ b/test/api/js/delay.mjs
@@ -1,0 +1,13 @@
+export default {
+    meta: {
+        url: "/api/delay",
+        method: "GET",
+    },
+    defaultResponse: {
+        status: 200,
+        delay: 1000,
+        body: {
+            message: "default",
+        },
+    },
+};

--- a/test/browser/match-request.spec.mjs
+++ b/test/browser/match-request.spec.mjs
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { matchRequest } from "../../src/browser";
 import advancedGetMock from "../api/js/body-fn.mjs";
 import advancedPostMock from "../api/js/body-fn_post.mjs";
+import delayMock from "../api/js/delay.mjs";
 import basicMockPost from "./basic-mock-post.mjs";
 import basicMock from "./basic-mock.mjs";
 
@@ -84,6 +85,30 @@ describe("browser", function () {
                 { contentType: "text/plain", fileName: "blob" },
                 { contentType: "text/plain", fileName: "blob" },
             ]);
+        });
+
+        it("should delay the response when calling delay mock", async () => {
+            expect.assertions(4);
+            vi.useFakeTimers();
+
+            const req = new Request("/api/delay", { method: "GET" });
+            const responsePromise = matchRequest([delayMock], req);
+
+            const spy = vi.fn();
+            responsePromise.then(spy);
+
+            await vi.advanceTimersByTimeAsync(998);
+            expect(spy).not.toHaveBeenCalled();
+
+            await vi.advanceTimersByTimeAsync(2);
+            expect(spy).toHaveBeenCalled();
+
+            const response = await responsePromise;
+            const body = await response.json();
+            expect(response.status).toBe(200);
+            expect(body).toEqual({ message: "default" });
+
+            vi.useRealTimers();
         });
     });
 });

--- a/test/commontest/inline-mock.spec.mjs
+++ b/test/commontest/inline-mock.spec.mjs
@@ -54,4 +54,19 @@ describe("inline mock", function () {
         );
         expect(res.status).to.equal(500);
     });
+
+    it("should delay the response by 1000ms when calling inline-delay", async () => {
+        expect.assertions(3);
+        const DELAY_TIME = 1000;
+        const starttime = Date.now();
+        const res = await fetch(`http://${hostname}/inline-delay`, {
+            method: "get",
+        });
+        const endtime = Date.now();
+        const executionTime = endtime - starttime;
+        const body = await res.json();
+        expect(res.status).to.equal(200);
+        expect(body).to.deep.equal({ message: "delayed response" });
+        expect(executionTime).to.be.at.least(DELAY_TIME);
+    });
 });

--- a/test/inline-api.mjs
+++ b/test/inline-api.mjs
@@ -35,4 +35,16 @@ export default [
         meta: { url: "/inline-no-method/" },
         defaultResponse: { status: 200, body: {} },
     },
+    {
+        meta: {
+            url: "/inline-delay",
+            method: "GET",
+        },
+
+        defaultResponse: {
+            status: 200,
+            delay: 1000,
+            body: { message: "delayed response" },
+        },
+    },
 ];


### PR DESCRIPTION
Only applied to matchRequest since existing function `matchResponseBrowser` is not async cannot support delay.
As mentioned in previous Pull request the aim is to remove that function.