### PR TITLE
fix: inline mocks should only match if url exactly matches

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,11 +48,18 @@ const defaultConfig: MiddlewareConfiguration = {
  * @returns List of matching index or empty list if no match was found
  */
 function findMachingIndex(url: string): number[] {
+    function urlMatches(config: NormalizedEntry): boolean {
+        if (config.inlineMock !== undefined) {
+            return new URL(url, "https://x").pathname === config.mockurl;
+        }
+        return url.startsWith(config.mockurl);
+    }
+
     const found: number[] = [];
     /* eslint-disable-next-line @typescript-eslint/no-for-in-array -- technical debt */
     for (const i in mockOptions) {
         const config = mockOptions[i];
-        if (!url.startsWith(config.mockurl)) {
+        if (!urlMatches(config)) {
             continue;
         }
         if (found.length === 0) {

--- a/test/browser/match-request.spec.mjs
+++ b/test/browser/match-request.spec.mjs
@@ -18,6 +18,29 @@ async function getMockResponse(url, method = "GET", headers = {}, body) {
 
 describe("browser", function () {
     describe("matchMockByRequest", function () {
+        it("should return default GET response", async () => {
+            expect.assertions(2);
+            const response = await getMockResponse("/private/foo/basic", "GET");
+            const body = await response.json();
+            expect(body).toEqual({
+                foo: "bar",
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it("should return 404 if the url does not exactly match", async () => {
+            expect.assertions(2);
+            const response = await getMockResponse(
+                "/private/foo/basic404",
+                "GET",
+            );
+            const body = await response.json();
+            expect(body).toEqual({
+                response: "default 404 - @forsakringskassan/apimock-express",
+            });
+            expect(response.status).toBe(404);
+        });
+
         it("should return 404 response if no match", async () => {
             expect.assertions(2);
             const response = await getMockResponse("/not-found", "GET", {

--- a/test/commontest/inline-mock.spec.mjs
+++ b/test/commontest/inline-mock.spec.mjs
@@ -13,6 +13,14 @@ describe("inline mock", function () {
         expect(body).to.deep.equal({ message: "inline default response" });
     });
 
+    it("should return 404 if url not exact match", async () => {
+        expect.assertions(1);
+        const res = await fetch(`http://${hostname}/inline/resource404`, {
+            method: "get",
+        });
+        expect(res.status).to.equal(404);
+    });
+
     it("should return the matched response for a matching request parameter", async () => {
         expect.assertions(2);
         const res = await fetch(

--- a/test/inline-api.mjs
+++ b/test/inline-api.mjs
@@ -1,6 +1,6 @@
 export default [
     {
-        meta: { url: "/inline/", method: "GET" },
+        meta: { url: "/inline/resource", method: "GET" },
         defaultResponse: {
             status: 200,
             body: { message: "inline default response" },
@@ -16,7 +16,7 @@ export default [
         ],
     },
     {
-        meta: { url: "/inline/", method: "POST" },
+        meta: { url: "/inline/resource", method: "POST" },
         defaultResponse: {
             status: 200,
             body: { message: "inline post default response" },
@@ -32,7 +32,7 @@ export default [
         ],
     },
     {
-        meta: { url: "/inline-no-method/" },
+        meta: { url: "/inline-no-method/resource" },
         defaultResponse: { status: 200, body: {} },
     },
     {


### PR DESCRIPTION
Request url `/foo-404` should not match if **meta.url** for inline mock only is `/foo`.

i would like to see some sort of glob solution if this is a wanted behavior, i.e that **meta.url** could be defined as `/foo*`.

I assume there is some issues here regarding trailing slashes in the config, i will solve that in a separate pull request (And add specific tests for that)